### PR TITLE
[WORKFLOW]: fix the way I called environment variables

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         env:
             MONGODB_PASSWORD: ${{ secrets.MONGODB_PASSWORD }}
-            MONGODB_NAME: $MONGODB_NAME
+            MONGODB_NAME: ${{ vars.MONGODB_NAME }}
 
         steps:
         - uses: actions/checkout@v4


### PR DESCRIPTION
When we need to use environment variables, we can just use *vars*. 

https://github.com/orgs/community/discussions/42133#discussion-4677535